### PR TITLE
Prevent name mangling on dt_socket and dt_shell dynamic link libraries

### DIFF
--- a/make/lib/Lib-jdk.jdi.gmk
+++ b/make/lib/Lib-jdk.jdi.gmk
@@ -37,6 +37,7 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
           jdk.jdwp.agent:include \
           jdk.jdwp.agent:libjdwp/export, \
       LDFLAGS := $(LDFLAGS_JDKLIB), \
+      LDFLAGS_windows := -export:jdwpTransport_OnLoad, \
       LIBS := $(JDKLIB_LIBS), \
   ))
 

--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -37,6 +37,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBDT_SOCKET, \
         libjdwp/export, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
+    LDFLAGS_windows := -export:jdwpTransport_OnLoad, \
     LIBS_linux := -lpthread, \
     LIBS_solaris := -lnsl -lsocket, \
     LIBS_windows := $(JDKLIB_LIBS) ws2_32.lib, \


### PR DESCRIPTION
While MSVC does not apply name decoration for stdcall exported functions when building 64-bit libraries but it does when building for 32-bit. This prevents `jshell.exe` to execute on 32-bit builds of JDK, because the expected exported function name `jdwpTransport_OnLoad` on `dt_socket.dll` is decorated as `_jdwpTransport_OnLoad@16`.

This PR sets linker flags on both `dt_socket` and `dt_shmem` targets, so that name decoration is not applied to `jdwpTransport_OnLoad` which plays a role of entry function. These options were present for previous versions of JDK, but totally removed in JDK11.

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/709, and replaces https://github.com/AdoptOpenJDK/openjdk-jdk11/pull/6.