### PR TITLE
Revert previous name mangling fix PR#1 - a0cd3bc

### DIFF
--- a/make/lib/Lib-jdk.jdi.gmk
+++ b/make/lib/Lib-jdk.jdi.gmk
@@ -37,7 +37,6 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
           jdk.jdwp.agent:include \
           jdk.jdwp.agent:libjdwp/export, \
       LDFLAGS := $(LDFLAGS_JDKLIB), \
-      LDFLAGS_windows := -export:jdwpTransport_OnLoad, \
       LIBS := $(JDKLIB_LIBS), \
   ))
 

--- a/make/lib/Lib-jdk.jdwp.agent.gmk
+++ b/make/lib/Lib-jdk.jdwp.agent.gmk
@@ -37,7 +37,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBDT_SOCKET, \
         libjdwp/export, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
-    LDFLAGS_windows := -export:jdwpTransport_OnLoad, \
     LIBS_linux := -lpthread, \
     LIBS_solaris := -lnsl -lsocket, \
     LIBS_windows := $(JDKLIB_LIBS) ws2_32.lib, \


### PR DESCRIPTION
Since the upstream patch for [JDK-8214122](https://bugs.openjdk.java.net/browse/JDK-8214122) is already applied to jdk11u, we can now reverse our previous interim patch. 