### PR TITLE
Fix 8215123: Crash in runtime image built with jlink --compress=2

### DIFF
--- a/src/java.base/share/native/libjimage/imageDecompressor.cpp
+++ b/src/java.base/share/native/libjimage/imageDecompressor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,8 +38,8 @@
 #include <dlfcn.h>
 #endif
 
-typedef jboolean (JNICALL *ZipInflateFully_t)(void *inBuf, jlong inLen,
-                                              void *outBuf, jlong outLen, char **pmsg);
+typedef jboolean (*ZipInflateFully_t)(void *inBuf, jlong inLen,
+                                      void *outBuf, jlong outLen, char **pmsg);
 static ZipInflateFully_t ZipInflateFully        = NULL;
 
 #ifndef WIN32


### PR DESCRIPTION
This PR contains an interim commit that applies the upstream fix for the bug [8215123](https://bugs.openjdk.java.net/browse/JDK-8215123) we had reported earlier, until it's applied to jdk11u.

Related to [#763](https://github.com/AdoptOpenJDK/openjdk-build/issues/763).